### PR TITLE
Fix KDoc reference to SpellHandler

### DIFF
--- a/src/main/kotlin/idiotamspielen/vttproject/controllers/SpellCreationController.kt
+++ b/src/main/kotlin/idiotamspielen/vttproject/controllers/SpellCreationController.kt
@@ -11,7 +11,7 @@ import tornadofx.Controller
  * Controller class responsible for creating spells.
  *
  * This class provides functionality for setting spell properties and
- * creating a spell using the `SpellCreator` class. It also ensures
+ * creating a spell using the `SpellHandler` class. It also ensures
  * that the created spell is valid and saved properly.
  */
 class SpellCreationController : Controller() {


### PR DESCRIPTION
## Summary
- update SpellCreationController KDoc to mention `SpellHandler`

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_68590ad911b8832b9122272e8837fcf8